### PR TITLE
v2 overhaul 

### DIFF
--- a/rubicon/src/contracts/base_contract.rs
+++ b/rubicon/src/contracts/base_contract.rs
@@ -1,0 +1,40 @@
+use ethers::providers::Middleware;
+use ethers::signers::Signer;
+// import libraries
+use ethers::{abi::Address, signers::Signer::address};
+use ethers::prelude::*;
+use ethers::contract::Contract; //this is the import for a contract
+use ethers::core::types::Address; //address type
+use ethers::core::types::Chain; //rust has built in chain IDs
+
+// Base class representation of a contract that defines the structure of a contract and provides 
+// methods that can be used by Rubicon contracts 
+// Current contracts are erc20, market, and router.
+// Aid support is not available 
+pub struct BaseContract {
+    w3: Provider, //not sure if this is supposed to be middleware. also might need <Http> type? idk
+    contract: Contract, //contract instance 
+    wallet: Option<Address>, //optional signer wallet address
+    key: Option<str> //pk of signer 
+}
+
+// implementation of base contract
+impl BaseContract {
+    pub fn new(
+        w3: Provider,
+        contract: Contract,
+        wallet: Option<Address>,
+        key: Option<str>,
+    ) -> Result<Self, String> {
+            if wallet.is_some() != key.is_some() {
+                return Err(String::from("Both a wallet and a key are required sign txns. Provide both or provide none")) //"Both a wallet and a key are required sign txns. Provide both or provide none".to_owned()
+            }
+            let chain_id = w3.get_chainid().await.map_err(|e| e.to_string())?;
+            Ok(BaseContract{
+                w3,
+                contract,
+                wallet,
+                key
+            })
+        }
+}


### PR DESCRIPTION
This PR starts the journey of overhauling this repo to work with Rubicon V2. This will be a slow and steady process as I continue adding in features. Here's a rough plan of how I want to build this 

1. Start implementing the contracts in Rust following `rubi-py`. This starts with creating a `base_contract` class and then creating the `erc20`, `market`, and `router` contracts. This should serve as an MVP for this repo as it can allow other Rust devs to use these contracts and build their trading frameworks on top
2. Overhauling `RubiconSession` with a `Client` style framework again following the groundwork of `rubi-py`

Let's see how this goes. Goal is to become a full Rusteacean 🦀 after finishing this